### PR TITLE
Create cache objects without prototype

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 module.exports = function (max) {
-  var size = 0, cache = {}, _cache = {}
+  var size = 0, cache = Object.create(null), _cache = Object.create(null)
 
   function update (key, value) {
     cache[key] = value
@@ -7,7 +7,7 @@ module.exports = function (max) {
     if(size >= max) {
       size = 0
       _cache = cache
-      cache = {}
+      cache = Object.create(null)
     }
   }
 
@@ -26,14 +26,3 @@ module.exports = function (max) {
     }
   }
 }
-
-
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
This will fix getting and setting `constructor` key.